### PR TITLE
add -no-pie option

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -2,7 +2,7 @@ all: bin/check
 
 bin/check: check.c
 	mkdir -p bin
-	gcc check.c -o ./bin/check
+	gcc -no-pie check.c -o ./bin/check
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
I encountered the following error when tried to build the `util`:

``/usr/bin/ld: /tmp/ccAKVV4D.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC /usr/bin/ld: final link failed: Nonrepresentable section on output collect2: error: ld returned 1 exit status``

[Details](https://stackoverflow.com/questions/46123505/assembling-with-gcc-causes-weird-relocation-error-with-regards-to-data)

The solution is in the pull request.