### PR TITLE
nopie for util compilation

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -2,7 +2,7 @@ all: bin/check
 
 bin/check: check.c
 	mkdir -p bin
-	gcc check.c -o ./bin/check
+	gcc -no-pie check.c -o ./bin/check
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
fix #1

Using -no-pie for compiling the utils since the assembly isn't written position independent.
Newer GCC versions default to PIE, so this should be set explicitly.

Signed-off-by: benaryorg <binary@benary.org>