### PR TITLE
fix relocation R_X86_64_32 against `.text' error

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -2,7 +2,7 @@ all: bin/check
 
 bin/check: check.c
 	mkdir -p bin
-	gcc check.c -o ./bin/check
+	gcc check.c -o ./bin/check -no-pie -fno-pie
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
* fixes building `util/check.c` in Arch Linux